### PR TITLE
Simplify script usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ A python script to collect FLEx metadata from a list of local project folders an
 ### Quickstart
 
 - `cd src`
-- run `./getDependences.sh` to automate installing the above dependencies with apt-get
+- run `./installDependencies.sh` to automate installing the above dependencies with apt-get
 - run `./setupPostgresql.sh` to automate creating a role for the database we'll use
 - run `./createDb.sh` to initialize the database
 - run `./runAnalysis.py` to start analyzing the data

--- a/README.md
+++ b/README.md
@@ -19,17 +19,20 @@ A python script to collect FLEx metadata from a list of local project folders an
 - Download the script with `git clone https://github.com/sillsdev/flex-languagedepot-metadata`
 - Run the script in `src/runAll.sh`
 
-You can specify an output file name if you wish: `runAll.sh output.csv`. The
-default file name is `export.csv` and will be in the directory where you ran the
-command.
+By default the script will run on the sample data and save the output to `export.csv`. To run on a different dataset pass the path to the directory containing the projects you want to analyze. For example:
+```
+src/runAll.sh path/to/directory/containing/flex/projects output_file.csv
+```
+Both parameters are optional, but you must specify the first if you want to specify the second.
 
 ### Longer setup
 
 - `cd src`
-- run `./installDependencies.sh` to automate installing the above dependencies with apt-get
-- run `./setupPostgresql.sh` to automate creating a role for the database we'll use
-- run `./createDb.sh` to initialize the database
-- run `./runAnalysis.py` to start analyzing the data
+- run `./installDependencies.sh` to automate installing the above dependencies with apt-get.
+- run `./setupPostgresql.sh` to automate creating a role for the database we'll use.
+- run `./createDb.sh` to initialize the database, or delete and recreate it.
+- run `./runAnalysis.py` to start analyzing the data. You can specify a path to the directory containing the projects you want to analyze.
+- run `./saveAsCSV.sh` to export the data from the database. You can specify a file name to save the data in.
 
 ### Detailed Setup
 

--- a/README.md
+++ b/README.md
@@ -16,6 +16,15 @@ A python script to collect FLEx metadata from a list of local project folders an
 
 ### Quickstart
 
+- Download the script with `git clone https://github.com/sillsdev/flex-languagedepot-metadata`
+- Run the script in `src/runAll.sh`
+
+You can specify an output file name if you wish: `runAll.sh output.csv`. The
+default file name is `export.csv` and will be in the directory where you ran the
+command.
+
+### Longer setup
+
 - `cd src`
 - run `./installDependencies.sh` to automate installing the above dependencies with apt-get
 - run `./setupPostgresql.sh` to automate creating a role for the database we'll use

--- a/src/createDb.sh
+++ b/src/createDb.sh
@@ -1,7 +1,15 @@
+#!/bin/bash
+
+# cd to the directory of this script
+cd "$(dirname "$0")" || exit
+
 # using a user with createdb and dropdb roles, or the user postgres
-echo Emptying languagedepot-metadata database
+echo "Emptying the languagedepot-metadata database."
+
 dropdb languagedepot-metadata --if-exists
 createdb languagedepot-metadata
+
 python3 createDb.py
 psql languagedepot-metadata < languagedepot-metadata.sql
-echo Done
+
+echo Finished

--- a/src/createDb.sh
+++ b/src/createDb.sh
@@ -12,4 +12,4 @@ createdb languagedepot-metadata
 python3 createDb.py
 psql languagedepot-metadata < languagedepot-metadata.sql
 
-echo Finished
+echo Database created

--- a/src/getDependencies.sh
+++ b/src/getDependencies.sh
@@ -1,3 +1,0 @@
-#!/bin/bash
-
-sudo apt-get install python3 postgresql python3-psycopg2 mercurial

--- a/src/getDependencies.sh
+++ b/src/getDependencies.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-sudo apt-get install python3 postgresql python3-psycopg2
+sudo apt-get install python3 postgresql python3-psycopg2 mercurial

--- a/src/installDependencies.sh
+++ b/src/installDependencies.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+
+# Installs dependencies if they're not installed already. If the --quiet option
+# is given there will be no output if dependencies are already met.
+
+declare -a deps=(python3 postgresql python3-psycopg2 mercurial)
+
+function areUnmetDependencies {
+  for dep in "${deps[@]}"; do
+    if ! dpkg-query -l "$dep" &> /dev/null
+    then
+      return 0
+    fi
+  done
+  return 1
+}
+
+if areUnmetDependencies
+then
+  echo "Installing required software."
+  echo "You may be prompted for the password for the $(whoami) user."
+  echo "As you type the password no output will be shown."
+  echo
+  sudo apt-get install "${deps[@]}"
+elif ! [ "$1" == "--quiet" ]
+then
+  echo "All required software is installed."
+fi

--- a/src/runAll.sh
+++ b/src/runAll.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+# Run everything necessary to get an output file in one command
+
+ORIGINAL_CWD=`pwd`
+
+# cd to the directory of this script
+cd "$(dirname "$0")" || exit
+
+./installDependencies.sh --quiet
+./setupPostgresql.sh
+./createDb.sh
+./runAnalysis.py
+
+DIR=`pwd`
+
+# Go back to the original CWD so the file will be saved in the right place
+
+cd $ORIGINAL_CWD || exit
+
+exec "$DIR/saveAsCSV.sh" $1

--- a/src/runAll.sh
+++ b/src/runAll.sh
@@ -10,7 +10,7 @@ cd "$(dirname "$0")" || exit
 ./installDependencies.sh --quiet
 ./setupPostgresql.sh
 ./createDb.sh
-./runAnalysis.py
+./runAnalysis.py $1
 
 DIR=`pwd`
 
@@ -18,4 +18,4 @@ DIR=`pwd`
 
 cd $ORIGINAL_CWD || exit
 
-exec "$DIR/saveAsCSV.sh" $1
+exec "$DIR/saveAsCSV.sh" $2

--- a/src/saveAsCSV.sh
+++ b/src/saveAsCSV.sh
@@ -1,3 +1,10 @@
+#!/bin/bash
+
+# Exports the database to a CSV file. The default file name is export.csv. This
+# may be overridden by passing the desired file name as an argument.
+
+OUTPUT=${1:-"export.csv"}
+
 # makes a csv
-echo Exporting table project.metadata to file export.csv
-psql languagedepot-metadata -c "\copy (SELECT * FROM project.metadata ORDER BY id) TO STDOUT WITH CSV HEADER" > export.csv
+echo Exporting table project.metadata to file $OUTPUT
+psql languagedepot-metadata -c "\copy (SELECT * FROM project.metadata ORDER BY id) TO STDOUT WITH CSV HEADER" > $OUTPUT

--- a/src/setupPostgresql.sh
+++ b/src/setupPostgresql.sh
@@ -1,14 +1,18 @@
 #!/bin/bash
 cd "$(dirname "$0")" || exit
 
-echo "Setting up a database user."
-echo "You may be prompted for the password for the $(whoami) user."
-echo "As you type the password no output will be shown."
-echo
+function createRole {
+  echo "Setting up a database user."
+  echo "You may be prompted for the password for the $USERNAME user."
+  echo "As you type the password no output will be shown."
+  echo
+  sudo -u postgres psql -c "CREATE ROLE $USERNAME WITH LOGIN CREATEDB PASSWORD 'placeholder'"
+}
 
-sudo -u postgres psql -c "CREATE ROLE $USERNAME WITH LOGIN CREATEDB PASSWORD 'placeholder'" 2> /dev/null
+# If There is no Postgre role with the username, create it
+[ $(psql postgres -tAc "SELECT 1 FROM pg_roles WHERE rolname='$USERNAME'") != "1" ] && createRole
 
 # Replaces "USERNAME" with the actual username in config.json
 sed -i "s/USERNAME/$USERNAME/" config.json
 
-echo Finished
+echo "Postgre setup done"

--- a/src/setupPostgresql.sh
+++ b/src/setupPostgresql.sh
@@ -1,8 +1,14 @@
 #!/bin/bash
-DIR=`dirname "$(readlink -f $0)"`
+cd "$(dirname "$0")" || exit
+
+echo "Setting up a database user."
+echo "You may be prompted for the password for the $(whoami) user."
+echo "As you type the password no output will be shown."
+echo
 
 sudo -u postgres psql -c "CREATE ROLE $USERNAME WITH LOGIN CREATEDB PASSWORD 'placeholder'" 2> /dev/null
-createdb $USERNAME
 
 # Replaces "USERNAME" with the actual username in config.json
-sed -i "s/USERNAME/$USERNAME/" $DIR/config.json
+sed -i "s/USERNAME/$USERNAME/" config.json
+
+echo Finished


### PR DESCRIPTION
These changes should make it much easier to run and use the script. Now it should be as simple as:
- `git clone https://github.com/sillsdev/flex-languagedepot-metadata`
- `cd flex-languagedepot-metadata/src`
- `./runAll.sh path/to/input/projects output.csv`

These CLI options are optional. It defaults to the test data and saves in `export.csv` in the current working directory.

Next I'm planning to work on Travis CI integration. To enable Travis CI one must have administrative access to a repository. Enabling it is explained here: https://docs.travis-ci.com/user/getting-started/#To-get-started-with-Travis-CI%3A