### PR TITLE
Replace $USERNAME with $USER

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,6 @@ dist: trusty
 sudo: required
 python:
   - "3.5"
-before_install:
-  - export USERNAME=$(whoami)
 install:
   - src/installDependencies.sh
   - pip install psycopg2

--- a/src/setupPostgresql.sh
+++ b/src/setupPostgresql.sh
@@ -3,10 +3,10 @@ cd "$(dirname "$0")" || exit
 
 function createRole {
   echo "Setting up a database user."
-  echo "You may be prompted for the password for the $USERNAME user."
+  echo "You may be prompted for the password for the $USER user."
   echo "As you type the password no output will be shown."
   echo
-  sudo -u postgres psql -c "CREATE ROLE $USERNAME WITH LOGIN CREATEDB PASSWORD 'placeholder'"
+  sudo -u postgres psql -c "CREATE ROLE $USER WITH LOGIN CREATEDB PASSWORD 'placeholder'"
 }
 
 # If There is no Postgre role with the username, create it
@@ -14,12 +14,12 @@ function createRole {
 # psql: FATAL:  role "user" does not exist
 if psql postgres -c "" &> /dev/null
 then
-  echo "PostgreSQL user $USERNAME already exists so it will not be created."
+  echo "PostgreSQL user $USER already exists so it will not be created."
 else
   createRole
 fi
 
 # Replaces "USERNAME" with the actual username in config.json
-sed -i "s/USERNAME/$USERNAME/" config.json
+sed -i "s/USERNAME/$USER/" config.json
 
 echo "Postgre setup done"


### PR DESCRIPTION
Fixes the issues with `$USERNAME` not being defined. I wasn't able to determine the difference between the two and when they are defined, but Travis CI only defines `$USER`. I'm hypothesizing that it's the difference between trusty and xenial.